### PR TITLE
Add "No License" Option to Project License

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,14 +14,14 @@
     "AGPL-3.0",
     "Unlicense",
     "Apache-2.0",
-    "GPL-3.0"
+    "GPL-3.0",
+    "No License"
   ],
   "project_version": "0.1.0",
   "project_uses_semantic_versioning": true,
   "project_accepts_issues_prs": true,
   "template_python_version": "3.6.9",
   "template_version": "0.1.0",
-
   "_inner_dir": "{{cookiecutter.project_slug}}",
   "_copy_without_render": ["*.donotrender"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -23,6 +23,9 @@ def get_license():
     url = f"{base_url}/{project_license}"
     headers = {"Accept": "application/vnd.github.v3+json"}
 
+    if project_license == "No License".lower():
+        return
+
     try:
         req = Request(url, headers=headers)
     except urllib.error.HTTPError as e:

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.project_name }}
 
-[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme) [![code style black](https://img.shields.io/badge/code%20style-black-%23000000)](https://github.com/psf/black) [![License {{ cookiecutter.project_license }}](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }})](./LICENSE)
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme) [![code style black](https://img.shields.io/badge/code%20style-black-%23000000)](https://github.com/psf/black) {% if cookiecutter.project_license != "No License" %}[![License {{ cookiecutter.project_license }}](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }})](./LICENSE){% endif %}
 
 {% if cookiecutter.project_summary %}_{{ cookiecutter.project_summary }}_{% endif %}
 
@@ -61,7 +61,7 @@ _Small note: If editing the [README.md], please conform to the [standard-readme 
 
 ## License
 
-[{{ cookiecutter.project_license }}](./LICENSE) &copy; {{ cookiecutter.full_name }} 2020
+{% if cookiecutter.project_license != "No License" %}[{{ cookiecutter.project_license }}](./LICENSE) &copy; {{ cookiecutter.full_name }} 2020{% else %}{{ cookiecutter.project_license }}{% endif%}
 
 <!-- Links -->
 

--- a/{{cookiecutter.project_slug}}/cookiecutter.json
+++ b/{{cookiecutter.project_slug}}/cookiecutter.json
@@ -14,14 +14,14 @@
     "AGPL-3.0",
     "Unlicense",
     "Apache-2.0",
-    "GPL-3.0"
+    "GPL-3.0",
+    "No License"
   ],
   "project_version": "0.1.0",
   "project_uses_semantic_versioning": true,
   "project_accepts_issues_prs": true,
   "template_python_version": "3.6.9",
   "template_version": "0.1.0",
-
   "_inner_dir": "{{cookiecutter.project_slug}}",
   "_copy_without_render": ["*.donotrender"]
 }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter._inner_dir}}/README.md.donotrender
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter._inner_dir}}/README.md.donotrender
@@ -1,6 +1,6 @@
 # {{ cookiecutter.project_name }}
 
-[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme) [![code style black](https://img.shields.io/badge/code%20style-black-%23000000)](https://github.com/psf/black) [![License {{ cookiecutter.project_license }}](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }})](./LICENSE)
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme) [![code style black](https://img.shields.io/badge/code%20style-black-%23000000)](https://github.com/psf/black) {% if cookiecutter.project_license != "No License" %}[![License {{ cookiecutter.project_license }}](https://img.shields.io/github/license/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }})](./LICENSE){% endif %}
 
 {% if cookiecutter.project_summary %}_{{ cookiecutter.project_summary }}_{% endif %}
 
@@ -57,7 +57,7 @@ _Small note: If editing the [README.md], please conform to the [standard-readme 
 
 ## License
 
-[{{ cookiecutter.project_license }}](./LICENSE) &copy; {{ cookiecutter.full_name }} 2020
+{% if cookiecutter.project_license != "No License" %}[{{ cookiecutter.project_license }}](./LICENSE) &copy; {{ cookiecutter.full_name }} 2020{% else %}{{ cookiecutter.project_license }}{% endif%}
 
 <!-- Links -->
 


### PR DESCRIPTION
* Add "No License" option to **cookiecutter.json** -> **project_license**
* Add "No License" option to inner **cookiecutter.json**
* Update **post_gen_project.py** to return early if "No License" is selected
* Update generated README.md to skip rendering a link in **License** if "No License" is selected
* Update generated README.md to skip rendering the license badge if "No License" is selected
* Update inner generated README.md to skip rendering a link in **License** if "No License" is selected
* Update the inner generated README.md to skip rendering the license badge if "No License" is selected
* Fixes #2 